### PR TITLE
chore: 저장소명 변경 및 vercel deployment 워크플로우 추가

### DIFF
--- a/.github/.workflows/deployment.yml
+++ b/.github/.workflows/deployment.yml
@@ -1,0 +1,37 @@
+name: git push into another repo to deploy to vercel
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      - name: creates output
+        run: sh ./build.sh
+      - name: Set target branch
+        id: set_target_branch
+        run: echo "::set-output name=target_branch::${{ github.ref_name }}"
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.ACCESS_KEY }}
+        with:
+          source-directory: 'output'
+          destination-github-username: kimsuyeon0916
+          destination-repository-name: finpik_frontend
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: ${{ steps.set_target_branch.outputs.target_branch }}
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./frontend/* ./output
+cp -R ./output ./frontend

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "finpik",
   "private": true,
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
## 변경 사항

- 저장소명 변경
- github action 빌드 파일 추가
- vercel deployment 워크플로우 추가

## 리뷰 필요

- 핀픽 레포 main, develop 브랜치에 푸쉬하면, 개인 레포로 푸쉬되고 vercel 빌드 및 배포 자동화 설정하였습니다.

close #3 
